### PR TITLE
로그인 후 만료된 액세스 토큰으로 재접속 시 헤더 로그인 처리 오류

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -8,13 +8,18 @@ const router = createRouter({
   routes
 });
 
-router.beforeEach((to) => {
+router.beforeEach(async (to) => {
   const authStore = useAuthStore();
   const alertStore = useAlertStore();
+  const {accessToken, silentRefresh} = authStore;
   const {showAlert} = alertStore;
 
+  if (accessToken) {
+    await silentRefresh();
+  }
+
   if (to.meta.requiresAuth) {
-    if (!authStore.accessToken) {
+    if (!accessToken) {
       showAlert('로그인 후 이용바랍니다', 'warning')
       return {
         path: '/'


### PR DESCRIPTION
#51 에 관한 오류 처리를 했다.

## 변경사항
- 네비게이션 가드에서 라우팅 전 인증 갱신 기능을 추가했다.
- 액세스 토큰이 스토어에 있다면 리프레시 API를 호출하여 새로운 액세스 토큰을 발급받는다.
- 만료된 토큰으로 요청 시 액세스 토큰을 재발급한다.

This closes #51 